### PR TITLE
Fix code scanning alert no. 7: Incomplete regular expression for hostnames

### DIFF
--- a/themes/next/source/js/utils.js
+++ b/themes/next/source/js/utils.js
@@ -194,7 +194,7 @@ NexT.utils = NexT.$u = {
         wrap.appendChild(iframe);
 
         // Additional adjustments for 163 Music
-        if (this.src.search('music.163.com') > 0) {
+        if (this.src.search('music\\.163\\.com') > 0) {
           newDimension = getDimension($iframe);
           var shouldRecalculateAspect = newDimension.width > oldDimension.width
                                      || newDimension.height < oldDimension.height;


### PR DESCRIPTION
Fixes [https://github.com/isdaniel/MyBlog/security/code-scanning/7](https://github.com/isdaniel/MyBlog/security/code-scanning/7)

To fix the problem, we need to escape the `.` character in the regular expression to ensure it matches only the literal `.` character and not any character. This can be done by replacing `music.163.com` with `music\.163\.com`. This change ensures that the regular expression will only match the exact hostname `music.163.com` and not any other unintended hostnames.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
