### PR TITLE
Fix code scanning alert no. 16: Unsafe jQuery plugin

### DIFF
--- a/themes/next/source/lib/jquery_lazyload/jquery.lazyload.js
+++ b/themes/next/source/lib/jquery_lazyload/jquery.lazyload.js
@@ -69,11 +69,21 @@
             }
 
             $.extend(settings, options);
+
+            /* Validate settings.container to ensure it is a valid CSS selector */
+            try {
+                if (settings.container !== window) {
+                    $window.find(settings.container);
+                }
+            } catch (e) {
+                console.error("Invalid CSS selector for container:", settings.container);
+                settings.container = window;
+            }
         }
 
         /* Cache container as jQuery as object. */
         $container = (settings.container === undefined ||
-                      settings.container === window) ? $window : $(settings.container);
+                      settings.container === window) ? $window : $window.find(settings.container);
 
         /* Fire one scroll event per scroll. Not one scroll event per image. */
         if (0 === settings.event.indexOf("scroll")) {


### PR DESCRIPTION
Fixes [https://github.com/isdaniel/MyBlog/security/code-scanning/16](https://github.com/isdaniel/MyBlog/security/code-scanning/16)

To fix the problem, we need to ensure that the `settings.container` option is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing `settings.container` to the jQuery selector. Additionally, we should validate the `settings.container` to ensure it is a valid CSS selector.

1. Modify the code to use `jQuery.find` for `settings.container`.
2. Add validation to ensure `settings.container` is a valid CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
